### PR TITLE
Fix for Delivery Metrics order inside the Delivery Report

### DIFF
--- a/src/main/java/com/deloitte/ddwatch/dtos/ProjectDTO.java
+++ b/src/main/java/com/deloitte/ddwatch/dtos/ProjectDTO.java
@@ -11,6 +11,7 @@ import javax.validation.constraints.NotNull;
 import javax.validation.constraints.Size;
 import java.io.Serializable;
 import java.time.LocalDateTime;
+import java.util.List;
 import java.util.Set;
 
 @Data
@@ -48,7 +49,7 @@ public class ProjectDTO implements Serializable {
 
     private LocalDateTime lastQualityReport;
 
-    private Set<@Valid DeliveryReportDTO> deliveryReports;
+    private List<@Valid DeliveryReportDTO> deliveryReports;
 
     private LocalDateTime lastDeliveryReport;
 

--- a/src/main/java/com/deloitte/ddwatch/mockunit/ProjectMock.java
+++ b/src/main/java/com/deloitte/ddwatch/mockunit/ProjectMock.java
@@ -5,6 +5,7 @@ import net.andreinc.mockneat.abstraction.MockUnit;
 import net.andreinc.mockneat.abstraction.MockUnitDouble;
 import net.andreinc.mockneat.abstraction.MockUnitInt;
 
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
 import java.time.Period;
@@ -25,7 +26,7 @@ import static net.andreinc.mockneat.unit.user.Names.names;
 public class ProjectMock implements MockUnit<Project> {
     // Dates related
     public static final MockUnit<LocalDateTime> thisMonth = localDates()
-            .thisMonth()
+            .past(LocalDate.now().minus(Period.ofMonths(1)))
             .map(v -> LocalDateTime.of(v, LocalTime.of(0,0)));
 
     public static final LocalDateTime lastMonth = LocalDateTime.now().minus(Period.ofMonths(1));
@@ -75,20 +76,24 @@ public class ProjectMock implements MockUnit<Project> {
                 .setter(Project::setLastQualityReport, thisMonth)
                 .setter(Project::setLastDeliveryReport, thisMonth)
                 .map(p -> {
-                    Set<DeliveryReport> deliveryReports = filler(DeliveryReport::new)
+                    List<DeliveryReport> deliveryReports = filler(DeliveryReport::new)
                             .constant(DeliveryReport::setProject, p)
                             .setter(DeliveryReport::setUpdateDate, thisMonth)
-                            .constant(DeliveryReport::setMetricsReport,
-                                        filler(MetricsReport::new)
-                                                .constant(MetricsReport::setCreatedOn, lastMonth)
-                                                .setter(MetricsReport::setDeliveryValue, numericValues)
-                                                .setter(MetricsReport::setDeliveryStatus, from(metricStatuses))
-                                                .setter(MetricsReport::setInvoicingValue, from(invoicingValues))
-                                                .setter(MetricsReport::setInvoicingStatus, from(metricStatuses))
-                                                .setter(MetricsReport::setChangeOrderValue, from(changeOrderValues))
-                                                .setter(MetricsReport::setChangeOrderStatus, from(metricStatuses))
-                                                .get())
-                            .set(5)
+                            .map(thisDeliveryReport -> {
+                                thisDeliveryReport.setMetricsReport(filler(MetricsReport::new)
+                                        .constant(MetricsReport::setCreatedOn, lastMonth)
+                                        .setter(MetricsReport::setDeliveryValue, numericValues)
+                                        .setter(MetricsReport::setDeliveryStatus, from(metricStatuses))
+                                        .setter(MetricsReport::setInvoicingValue, from(invoicingValues))
+                                        .setter(MetricsReport::setInvoicingStatus, from(metricStatuses))
+                                        .setter(MetricsReport::setChangeOrderValue, from(changeOrderValues))
+                                        .setter(MetricsReport::setChangeOrderStatus, from(metricStatuses))
+                                        .get());
+
+                                return thisDeliveryReport;
+
+                            })
+                            .list(5)
                             .get();
                     p.setDeliveryReports(deliveryReports);
 
@@ -102,92 +107,92 @@ public class ProjectMock implements MockUnit<Project> {
                             .constant(ProjectRepo::setUrl, "https://github.com/DeloitteDigitalRO/DDWatch/")
                             .map(projectRepo -> {
                                 Set<QualityReport> qualityReports = filler(QualityReport::new)
-                                                            .constant(QualityReport::setProjectRepo, projectRepo)
-                                                            .setter(QualityReport::setUpdateDate, thisYear)
-                                                            .map(thisQualityReport -> {
-                                                                thisQualityReport.setSonarQubeReport(
-                                                                    filler(SonarQubeReport::new)
-                                                                        .constant(SonarQubeReport::setQualityReport, thisQualityReport)
-                                                                        .constant(SonarQubeReport::setName, p.getName())
-                                                                        .constant(SonarQubeReport::setKey, projectRepo.getSonarComponentKey())
-                                                                        .setter(SonarQubeReport::setLinesOfCode, ints().range(10000, 50000))
+                                    .constant(QualityReport::setProjectRepo, projectRepo)
+                                    .setter(QualityReport::setUpdateDate, thisYear)
+                                    .map(thisQualityReport -> {
+                                        thisQualityReport.setSonarQubeReport(
+                                            filler(SonarQubeReport::new)
+                                                .constant(SonarQubeReport::setQualityReport, thisQualityReport)
+                                                .constant(SonarQubeReport::setName, p.getName())
+                                                .constant(SonarQubeReport::setKey, projectRepo.getSonarComponentKey())
+                                                .setter(SonarQubeReport::setLinesOfCode, ints().range(10000, 50000))
 
-                                                                        // Bugs
-                                                                        .setter(SonarQubeReport::setBlockerBugs, blocker)
-                                                                        .setter(SonarQubeReport::setCriticalBugs, critical)
-                                                                        .setter(SonarQubeReport::setMajorBugs, major)
-                                                                        .setter(SonarQubeReport::setMinorBugs, minor)
-                                                                        .setter(SonarQubeReport::setOtherBugs, other)
+                                                // Bugs
+                                                .setter(SonarQubeReport::setBlockerBugs, blocker)
+                                                .setter(SonarQubeReport::setCriticalBugs, critical)
+                                                .setter(SonarQubeReport::setMajorBugs, major)
+                                                .setter(SonarQubeReport::setMinorBugs, minor)
+                                                .setter(SonarQubeReport::setOtherBugs, other)
 
-                                                                        // Vulnerabilities
-                                                                        .setter(SonarQubeReport::setBlockerVulnerabilities, blocker)
-                                                                        .setter(SonarQubeReport::setCriticalVulnerabilities, critical)
-                                                                        .setter(SonarQubeReport::setMajorVulnerabilities, major)
-                                                                        .setter(SonarQubeReport::setMinorVulnerabilities, minor)
-                                                                        .setter(SonarQubeReport::setOtherVulnerabilities, other)
+                                                // Vulnerabilities
+                                                .setter(SonarQubeReport::setBlockerVulnerabilities, blocker)
+                                                .setter(SonarQubeReport::setCriticalVulnerabilities, critical)
+                                                .setter(SonarQubeReport::setMajorVulnerabilities, major)
+                                                .setter(SonarQubeReport::setMinorVulnerabilities, minor)
+                                                .setter(SonarQubeReport::setOtherVulnerabilities, other)
 
-                                                                        // Code Smells
-                                                                        .setter(SonarQubeReport::setBlockerCodeSmells, blocker)
-                                                                        .setter(SonarQubeReport::setCriticalCodeSmells, critical)
-                                                                        .setter(SonarQubeReport::setMajorCodeSmells, major)
-                                                                        .setter(SonarQubeReport::setMinorCodeSmells, minor)
-                                                                        .setter(SonarQubeReport::setOtherCodeSmells, other)
+                                                // Code Smells
+                                                .setter(SonarQubeReport::setBlockerCodeSmells, blocker)
+                                                .setter(SonarQubeReport::setCriticalCodeSmells, critical)
+                                                .setter(SonarQubeReport::setMajorCodeSmells, major)
+                                                .setter(SonarQubeReport::setMinorCodeSmells, minor)
+                                                .setter(SonarQubeReport::setOtherCodeSmells, other)
 
-                                                                        // Duplication
-                                                                        .setter(SonarQubeReport::setDuplicatedLines, ints().range(500, 5000))
-                                                                        .setter(SonarQubeReport::setDuplicatedBlocks, ints().range(10, 20))
-                                                                        .setter(SonarQubeReport::setDefectDensity, doubles().range(1,2))
+                                                // Duplication
+                                                .setter(SonarQubeReport::setDuplicatedLines, ints().range(500, 5000))
+                                                .setter(SonarQubeReport::setDuplicatedBlocks, ints().range(10, 20))
+                                                .setter(SonarQubeReport::setDefectDensity, doubles().range(1,2))
 
-                                                                        // Complexities
-                                                                        .setter(SonarQubeReport::setCyclomaticComplexity, ints().range(1000, 5000))
-                                                                        .setter(SonarQubeReport::setCognitiveComplexity, ints().range(1000, 5000))
+                                                // Complexities
+                                                .setter(SonarQubeReport::setCyclomaticComplexity, ints().range(1000, 5000))
+                                                .setter(SonarQubeReport::setCognitiveComplexity, ints().range(1000, 5000))
 
-                                                                        // Coverage
-                                                                        .setter(SonarQubeReport::setOverallCoverage, doubles().range(10, 90))
-                                                                        .setter(SonarQubeReport::setLineCoverage, doubles().range(10, 90))
-                                                                        .setter(SonarQubeReport::setConditionsCoverage, doubles().range(10, 90))
+                                                // Coverage
+                                                .setter(SonarQubeReport::setOverallCoverage, doubles().range(10, 90))
+                                                .setter(SonarQubeReport::setLineCoverage, doubles().range(10, 90))
+                                                .setter(SonarQubeReport::setConditionsCoverage, doubles().range(10, 90))
 
-                                                                        .map(sqr -> {
-                                                                            // Return total number of bugs
-                                                                            sqr.setTotalBugs(
-                                                                                    sqr.getBlockerBugs() +
-                                                                                            sqr.getCriticalBugs() +
-                                                                                            sqr.getMajorBugs() +
-                                                                                            sqr.getMinorBugs() +
-                                                                                            sqr.getOtherBugs()
-                                                                            );
-                                                                            // Return total number of vulnerabilities
-                                                                            sqr.setTotalVulnerabilities(
-                                                                                    sqr.getBlockerVulnerabilities() +
-                                                                                            sqr.getCriticalVulnerabilities() +
-                                                                                            sqr.getMajorVulnerabilities() +
-                                                                                            sqr.getMinorVulnerabilities() +
-                                                                                            sqr.getOtherVulnerabilities()
-                                                                            );
-                                                                            // Return total number of issues
-                                                                            sqr.setTotalCodeSmells(
-                                                                                    sqr.getBlockerCodeSmells() +
-                                                                                            sqr.getCriticalCodeSmells() +
-                                                                                            sqr.getMajorCodeSmells() +
-                                                                                            sqr.getMinorCodeSmells() +
-                                                                                            sqr.getOtherBugs()
-                                                                            );
-                                                                            // Rentru total number of issues
-                                                                            sqr.setTotalIssues(
-                                                                                    sqr.getTotalBugs() +
-                                                                                            sqr.getTotalVulnerabilities() +
-                                                                                            sqr.getTotalCodeSmells()
-                                                                            );
+                                                .map(sqr -> {
+                                                    // Return total number of bugs
+                                                    sqr.setTotalBugs(
+                                                            sqr.getBlockerBugs() +
+                                                                    sqr.getCriticalBugs() +
+                                                                    sqr.getMajorBugs() +
+                                                                    sqr.getMinorBugs() +
+                                                                    sqr.getOtherBugs()
+                                                    );
+                                                    // Return total number of vulnerabilities
+                                                    sqr.setTotalVulnerabilities(
+                                                            sqr.getBlockerVulnerabilities() +
+                                                                    sqr.getCriticalVulnerabilities() +
+                                                                    sqr.getMajorVulnerabilities() +
+                                                                    sqr.getMinorVulnerabilities() +
+                                                                    sqr.getOtherVulnerabilities()
+                                                    );
+                                                    // Return total number of issues
+                                                    sqr.setTotalCodeSmells(
+                                                            sqr.getBlockerCodeSmells() +
+                                                                    sqr.getCriticalCodeSmells() +
+                                                                    sqr.getMajorCodeSmells() +
+                                                                    sqr.getMinorCodeSmells() +
+                                                                    sqr.getOtherBugs()
+                                                    );
+                                                    // Rentru total number of issues
+                                                    sqr.setTotalIssues(
+                                                            sqr.getTotalBugs() +
+                                                                    sqr.getTotalVulnerabilities() +
+                                                                    sqr.getTotalCodeSmells()
+                                                    );
 
-                                                                            return sqr;
+                                                    return sqr;
 
-                                                                        })
-                                                                        .get()
-                                                                    );
-                                                                return thisQualityReport;
-                                                                })
-                                                                .set(10)
-                                                                .get();
+                                                })
+                                                .get()
+                                            );
+                                        return thisQualityReport;
+                                        })
+                                        .set(10)
+                                        .get();
 
                                 projectRepo.setQualityReports(qualityReports);
                                 return projectRepo;

--- a/src/main/java/com/deloitte/ddwatch/mockunit/ProjectMock.java
+++ b/src/main/java/com/deloitte/ddwatch/mockunit/ProjectMock.java
@@ -25,7 +25,7 @@ import static net.andreinc.mockneat.unit.user.Names.names;
 
 public class ProjectMock implements MockUnit<Project> {
     // Dates related
-    public static final MockUnit<LocalDateTime> thisMonth = localDates()
+    public static final MockUnit<LocalDateTime> pastMonthFromCurrentDate = localDates()
             .past(LocalDate.now().minus(Period.ofMonths(1)))
             .map(v -> LocalDateTime.of(v, LocalTime.of(0,0)));
 
@@ -73,14 +73,14 @@ public class ProjectMock implements MockUnit<Project> {
                 .constant(Project::setDescription, "Project description.")
                 .setter(Project::setDeliveryStatus, from(Status.class))
                 .setter(Project::setQualityStatus, from(Status.class))
-                .setter(Project::setLastQualityReport, thisMonth)
-                .setter(Project::setLastDeliveryReport, thisMonth)
+                .setter(Project::setLastQualityReport, pastMonthFromCurrentDate)
+                .setter(Project::setLastDeliveryReport, pastMonthFromCurrentDate)
                 .map(p -> {
                     List<DeliveryReport> deliveryReports = filler(DeliveryReport::new)
                             .constant(DeliveryReport::setProject, p)
-                            .setter(DeliveryReport::setUpdateDate, thisMonth)
-                            .map(thisDeliveryReport -> {
-                                thisDeliveryReport.setMetricsReport(filler(MetricsReport::new)
+                            .setter(DeliveryReport::setUpdateDate, pastMonthFromCurrentDate)
+                            .map(deliveryReport -> {
+                                deliveryReport.setMetricsReport(filler(MetricsReport::new)
                                         .constant(MetricsReport::setCreatedOn, lastMonth)
                                         .setter(MetricsReport::setDeliveryValue, numericValues)
                                         .setter(MetricsReport::setDeliveryStatus, from(metricStatuses))
@@ -90,7 +90,7 @@ public class ProjectMock implements MockUnit<Project> {
                                         .setter(MetricsReport::setChangeOrderStatus, from(metricStatuses))
                                         .get());
 
-                                return thisDeliveryReport;
+                                return deliveryReport;
 
                             })
                             .list(5)

--- a/src/main/java/com/deloitte/ddwatch/model/Project.java
+++ b/src/main/java/com/deloitte/ddwatch/model/Project.java
@@ -48,7 +48,7 @@ public class Project {
 
     @OneToMany(mappedBy = "project", fetch = FetchType.EAGER, cascade = CascadeType.ALL)
     @OrderBy(value = "updateDate DESC")
-    private Set<DeliveryReport> deliveryReports = new HashSet<>();
+    private List<DeliveryReport> deliveryReports = new ArrayList<>();
 
     @Column(name = "last_delivery_report")
     private LocalDateTime lastDeliveryReport;

--- a/src/test/java/com/deloitte/ddwatch/services/DeliveryReportServiceTest.java
+++ b/src/test/java/com/deloitte/ddwatch/services/DeliveryReportServiceTest.java
@@ -1,0 +1,89 @@
+package com.deloitte.ddwatch.services;
+
+import com.deloitte.ddwatch.dtos.DeliveryReportDTO;
+import com.deloitte.ddwatch.dtos.ProjectDTO;
+import com.deloitte.ddwatch.model.DeliveryReport;
+import com.deloitte.ddwatch.model.MetricsReport;
+import com.deloitte.ddwatch.model.Project;
+import com.deloitte.ddwatch.model.Status;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.datatype.jdk8.Jdk8Module;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import com.fasterxml.jackson.module.paramnames.ParameterNamesModule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.junit4.SpringRunner;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
+
+import javax.validation.Valid;
+import java.time.LocalDateTime;
+import java.time.Period;
+import java.util.List;
+
+import static org.junit.Assert.assertTrue;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@SpringBootTest
+@RunWith(SpringRunner.class)
+@AutoConfigureMockMvc
+public class DeliveryReportServiceTest {
+    private final ObjectMapper objectMapper = new ObjectMapper()
+            .registerModule(new ParameterNamesModule())
+            .registerModule(new Jdk8Module())
+            .registerModule(new JavaTimeModule());
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private ProjectService projectService;
+
+    @Test
+    public void test() throws Exception {
+
+        Project project = new Project();
+        project.setName("Test Name");
+        project.setDescription("Test Description");
+        project.setDeliveryLead("Test Delivery Lead");
+        project.setDeliveryLeadEmail("delivery@email.com");
+        project.setTechnicalLead("Test Technical Lead");
+        project.setTechnicalLeadEmail("technical@lead.com");
+        project.setDeliveryStatus(Status.GREEN);
+        project.setQualityStatus(Status.AMBER);
+
+        DeliveryReport deliveryReport1 = new DeliveryReport();
+        deliveryReport1.setUpdateDate(LocalDateTime.now().minus(Period.ofMonths(2)));
+        deliveryReport1.setMetricsReport(new MetricsReport());
+
+        DeliveryReport deliveryReport2 = new DeliveryReport();
+        deliveryReport2.setUpdateDate(LocalDateTime.now());
+        deliveryReport2.setMetricsReport(new MetricsReport());
+
+        DeliveryReport deliveryReport3 = new DeliveryReport();
+        deliveryReport3.setUpdateDate(LocalDateTime.now().minus(Period.ofMonths(1)));
+        deliveryReport3.setMetricsReport(new MetricsReport());
+
+        project.addDeliveryReport(deliveryReport1);
+        project.addDeliveryReport(deliveryReport2);
+        project.addDeliveryReport(deliveryReport3);
+
+        project = projectService.create(project);
+
+        MvcResult result = mockMvc.perform(MockMvcRequestBuilders.get("/projects/" + project.getId())).andExpect(status().isOk()).andReturn();
+
+        ProjectDTO projectDTO = objectMapper.readValue(result.getResponse().getContentAsString(), ProjectDTO.class);
+
+        projectService.removeProject(project);
+
+        List<@Valid DeliveryReportDTO> deliveryReports = projectDTO.getDeliveryReports();
+        assertTrue(deliveryReports.get(0).getUpdateDate().isEqual(deliveryReport2.getUpdateDate()));
+        assertTrue(deliveryReports.get(1).getUpdateDate().isEqual(deliveryReport3.getUpdateDate()));
+        assertTrue(deliveryReports.get(2).getUpdateDate().isEqual(deliveryReport1.getUpdateDate()));
+
+    }
+}


### PR DESCRIPTION
fixed DeliveryMetrics in ProjectMock, changed the deliveryReports from Set to List because it has to be ordered.